### PR TITLE
fix: enforce ownership check in RefreshUserWordExplanationAsync (#8)

### DIFF
--- a/src/NewWords.Api.Tests/Services/VocabularyServiceTests.cs
+++ b/src/NewWords.Api.Tests/Services/VocabularyServiceTests.cs
@@ -7,6 +7,7 @@ using NewWords.Api.Entities;
 using NewWords.Api.Services;
 using Api.Framework;
 using LLM;
+using LLM.Models;
 using Microsoft.Extensions.Logging;
 using NewWords.Api.Repositories;
 using System.Collections.Generic;
@@ -101,6 +102,115 @@ namespace NewWords.Api.Tests.Services
             result.Should().Be(correctEntry.Id);
             _wordCollectionRepoMock.Verify(r => r.UpdateAsync(It.IsAny<WordCollection>()), Times.Never);
         }
+        [Fact]
+        public async Task RefreshUserWordExplanationAsync_Succeeds_WhenCallerOwnsWord()
+        {
+            // Arrange
+            const int userId = 42;
+            var current = new WordExplanation
+            {
+                Id = 100, WordCollectionId = 5, WordText = "apple",
+                LearningLanguage = "en", ExplanationLanguage = "zh",
+                ProviderModelName = "prov:model-a",
+            };
+            _wordExplanationRepoMock.Setup(r => r.GetFirstOrDefaultAsync(
+                    It.IsAny<System.Linq.Expressions.Expression<Func<WordExplanation, bool>>>(), null))
+                .ReturnsAsync(current);
+            _userWordRepoMock.Setup(r => r.GetFirstOrDefaultAsync(
+                    It.IsAny<System.Linq.Expressions.Expression<Func<UserWord, bool>>>(), null))
+                .ReturnsAsync(new UserWord { UserId = userId, WordCollectionId = 5, WordExplanationId = 100 });
+            _wordExplanationRepoMock.Setup(r => r.GetListAsync(
+                    It.IsAny<System.Linq.Expressions.Expression<Func<WordExplanation, bool>>>(), null, true))
+                .ReturnsAsync(new List<WordExplanation> { current });
+            _configServiceMock.Setup(c => c.Agents)
+                .Returns(new List<Agent> { new() { Provider = "prov", ModelName = "model-b" } });
+            _configServiceMock.Setup(c => c.GetLanguageName("en")).Returns("English");
+            _configServiceMock.Setup(c => c.GetLanguageName("zh")).Returns("Chinese");
+            _languageServiceMock.Setup(l => l.GetMarkdownExplanationAsync(
+                    It.IsAny<Agent>(), "apple", "English", "Chinese"))
+                .ReturnsAsync("new markdown");
+            _wordExplanationRepoMock.Setup(r => r.InsertReturnIdentityAsync(It.IsAny<WordExplanation>()))
+                .ReturnsAsync(200L);
+
+            var service = CreateService();
+
+            // Act
+            var result = await service.RefreshUserWordExplanationAsync(userId, 100);
+
+            // Assert
+            result.MarkdownExplanation.Should().Be("new markdown");
+            result.ProviderModelName.Should().Be("prov:model-b");
+            result.Id.Should().Be(200L);
+            _wordExplanationRepoMock.Verify(r => r.InsertReturnIdentityAsync(It.IsAny<WordExplanation>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task RefreshUserWordExplanationAsync_Throws_AndDoesNoAiCallOrInsert_WhenCallerDoesNotOwnWord()
+        {
+            // Arrange
+            var current = new WordExplanation
+            {
+                Id = 100, WordCollectionId = 5, WordText = "apple",
+                LearningLanguage = "en", ExplanationLanguage = "zh",
+                ProviderModelName = "prov:model-a",
+            };
+            _wordExplanationRepoMock.Setup(r => r.GetFirstOrDefaultAsync(
+                    It.IsAny<System.Linq.Expressions.Expression<Func<WordExplanation, bool>>>(), null))
+                .ReturnsAsync(current);
+            // No matching UserWord for this caller.
+            _userWordRepoMock.Setup(r => r.GetFirstOrDefaultAsync(
+                    It.IsAny<System.Linq.Expressions.Expression<Func<UserWord, bool>>>(), null))
+                .ReturnsAsync((UserWord?)null);
+
+            var service = CreateService();
+
+            // Act
+            var act = () => service.RefreshUserWordExplanationAsync(999, 100);
+
+            // Assert
+            await act.Should().ThrowAsync<ArgumentException>().WithMessage("User word not found");
+            _languageServiceMock.Verify(l => l.GetMarkdownExplanationAsync(
+                It.IsAny<Agent>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            _wordExplanationRepoMock.Verify(r => r.InsertReturnIdentityAsync(It.IsAny<WordExplanation>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task RefreshUserWordExplanationAsync_Throws_WhenAllModelsUsed_ForOwningCaller()
+        {
+            // Arrange
+            const int userId = 42;
+            var current = new WordExplanation
+            {
+                Id = 100, WordCollectionId = 5, WordText = "apple",
+                LearningLanguage = "en", ExplanationLanguage = "zh",
+                ProviderModelName = "prov:model-a",
+            };
+            _wordExplanationRepoMock.Setup(r => r.GetFirstOrDefaultAsync(
+                    It.IsAny<System.Linq.Expressions.Expression<Func<WordExplanation, bool>>>(), null))
+                .ReturnsAsync(current);
+            _userWordRepoMock.Setup(r => r.GetFirstOrDefaultAsync(
+                    It.IsAny<System.Linq.Expressions.Expression<Func<UserWord, bool>>>(), null))
+                .ReturnsAsync(new UserWord { UserId = userId, WordCollectionId = 5, WordExplanationId = 100 });
+            // The only configured model has already produced an explanation for this word.
+            _wordExplanationRepoMock.Setup(r => r.GetListAsync(
+                    It.IsAny<System.Linq.Expressions.Expression<Func<WordExplanation, bool>>>(), null, true))
+                .ReturnsAsync(new List<WordExplanation> { current });
+            _configServiceMock.Setup(c => c.Agents)
+                .Returns(new List<Agent> { new() { Provider = "prov", ModelName = "model-a" } });
+
+            var service = CreateService();
+
+            // Act
+            var act = () => service.RefreshUserWordExplanationAsync(userId, 100);
+
+            // Assert
+            await act.Should().ThrowAsync<InvalidOperationException>()
+                .WithMessage("All available models have been used for this word");
+            _languageServiceMock.Verify(l => l.GetMarkdownExplanationAsync(
+                It.IsAny<Agent>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            _wordExplanationRepoMock.Verify(r => r.InsertReturnIdentityAsync(It.IsAny<WordExplanation>()), Times.Never);
+        }
+
         [Theory]
         [InlineData("**apple**", "apple")]
         [InlineData("**take off** (phrasal verb)", "take off")]

--- a/src/NewWords.Api/Controllers/VocabularyController.cs
+++ b/src/NewWords.Api/Controllers/VocabularyController.cs
@@ -107,7 +107,7 @@ namespace NewWords.Api.Controllers
                 throw new ArgumentException("User not authenticated or ID not found.");
             }
 
-            var refreshedExplanation = await vocabularyService.RefreshUserWordExplanationAsync(wordExplanationId);
+            var refreshedExplanation = await vocabularyService.RefreshUserWordExplanationAsync(userId, wordExplanationId);
             return new SuccessfulResult<WordExplanation>(refreshedExplanation);
         }
 

--- a/src/NewWords.Api/Services/VocabularyService.cs
+++ b/src/NewWords.Api/Services/VocabularyService.cs
@@ -273,7 +273,7 @@ namespace NewWords.Api.Services
             }
         }
 
-        public async Task<WordExplanation> RefreshUserWordExplanationAsync(long wordExplanationId)
+        public async Task<WordExplanation> RefreshUserWordExplanationAsync(int userId, long wordExplanationId)
         {
             // 1. Get current explanation
             var currentExplanation = await wordExplanationRepository.GetFirstOrDefaultAsync(we => we.Id == wordExplanationId);
@@ -281,6 +281,16 @@ namespace NewWords.Api.Services
             {
                 logger.LogWarning($"Word explanation not found for refresh - WordExplanationId: {wordExplanationId}");
                 throw new ArgumentException("Word explanation not found");
+            }
+
+            // 1b. Verify the caller actually owns this word before doing any LLM work.
+            var userWord = await userWordRepository.GetFirstOrDefaultAsync(uw =>
+                uw.UserId == userId &&
+                uw.WordCollectionId == currentExplanation.WordCollectionId);
+            if (userWord == null)
+            {
+                logger.LogWarning($"User word not found for refresh - UserId: {userId}, WordCollectionId: {currentExplanation.WordCollectionId}");
+                throw new ArgumentException("User word not found");
             }
 
             // 2. Get all existing explanations for this word

--- a/src/NewWords.Api/Services/interfaces/IVocabularyService.cs
+++ b/src/NewWords.Api/Services/interfaces/IVocabularyService.cs
@@ -9,7 +9,7 @@ namespace NewWords.Api.Services.interfaces
         Task<PageData<WordExplanation>> GetUserWordsAsync(int userId, int pageSize, int pageNumber);
         Task<WordExplanation> AddUserWordAsync(int userId, string wordText, string learningLanguageCode, string explanationLanguageCode);
         Task DelUserWordAsync(int userId, long wordExplanationId);
-        Task<WordExplanation> RefreshUserWordExplanationAsync(long wordExplanationId);
+        Task<WordExplanation> RefreshUserWordExplanationAsync(int userId, long wordExplanationId);
         Task<IList<WordExplanation>> MemoriesAsync(int userId, string localTimezone);
         Task<IList<WordExplanation>> MemoriesOnAsync(int userId, string localTimezone, string yyyyMMdd);
         Task<ExplanationsResponse> GetAllExplanationsForWordAsync(int userId, long wordCollectionId, string learningLanguage, string explanationLanguage);


### PR DESCRIPTION
Closes #8