### PR TITLE
ci: gate production deploy behind manual workflow_dispatch (#46)

### DIFF
--- a/.github/workflows/deploy_to_production.yml
+++ b/.github/workflows/deploy_to_production.yml
@@ -33,7 +33,12 @@ jobs:
 
   build-and-deploy:
     needs: test
-    if: github.event_name != 'pull_request'
+    # Production deploy is gated behind a deliberate manual dispatch (issue #46):
+    # a push/merge to master runs the `test` job only, so merging code no longer
+    # restarts prod or applies DB migrations. Ship prod by running this workflow
+    # from the Actions tab (Run workflow), which triggers the full pipeline below
+    # — migrations + restart + post-restart crash-loop health check.
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
 
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,9 @@ dotnet run --project src/NewWords.Api --launch-profile https
 - Database migrations are ordered, idempotent SQL scripts in `migration_scripts/` (`NN_<name>.sql`)
 - **Applied automatically on deploy** (issue #41): `migration_scripts/apply_migrations.sh` runs on the VPS during `deploy_to_production.yml`, after files are copied and before the service restarts, tracked by a `schema_migrations` ledger so each script runs exactly once. A migration failure fails the deploy before restart. Add a migration by dropping the next-numbered idempotent `NN_*.sql`; see `migration_scripts/README.md` (including the one-time baseline precondition for the first automated deploy).
 
+### Deploying to production (issue #46)
+Production deploy is **manually gated**, not push-triggered. A merge to `master` runs the `test` job in `.github/workflows/deploy_to_production.yml` (build + tests) but does **not** touch prod. To ship, run that workflow by hand: GitHub → **Actions** → *Deploy NewWords.Api to production* → **Run workflow** (`workflow_dispatch`). Only that manual run executes `build-and-deploy`, which applies pending DB migrations, restarts the systemd service, and runs the post-restart crash-loop health check. This decouples "code merged" from "users disrupted" so releases land at a deliberate time.
+
 ### Development URLs
 - HTTP: http://localhost:5116
 - HTTPS: https://localhost:7162


### PR DESCRIPTION
Closes #46

Gate the `build-and-deploy` job to `github.event_name == 'workflow_dispatch'` so a push/merge to `master` runs the `test` job only — no prod restart, no DB migrations. Production ships via a deliberate manual "Run workflow".

The trigger block (push / pull_request / workflow_dispatch) is unchanged, so CI tests still run on every push and PR. All deploy steps — publish, SCP, Apply DB migrations, systemd restart, and the post-restart crash-loop health check — are preserved and run on the manual dispatch. `CLAUDE.md` documents the manual release path.